### PR TITLE
Making the URLValueFormatter more resilient.

### DIFF
--- a/Spine/Resource.swift
+++ b/Spine/Resource.swift
@@ -162,7 +162,7 @@ open class Resource: NSObject, NSCoding {
 
 extension Resource {
 	override open var description: String {
-		return "\(resourceType)(\(id), \(url))"
+		return "\(resourceType)(\(String(describing: id)), \(String(describing: url)))"
 	}
 	
 	override open var debugDescription: String {

--- a/Spine/SerializeOperation.swift
+++ b/Spine/SerializeOperation.swift
@@ -50,7 +50,7 @@ class SerializeOperation: Operation {
 	// MARK: Serializing
 	
 	fileprivate func serializeResource(_ resource: Resource) -> [String: Any] {
-		Spine.logDebug(.serializing, "Serializing resource \(resource) of type '\(resource.resourceType)' with id '\(resource.id)'")
+		Spine.logDebug(.serializing, "Serializing resource \(resource) of type '\(resource.resourceType)' with id '\(String(describing: resource.id))'")
 		
 		var serializedData: [String: Any] = [:]
 		

--- a/Spine/ValueFormatter.swift
+++ b/Spine/ValueFormatter.swift
@@ -133,13 +133,16 @@ struct ValueFormatterRegistry {
 /// If a baseURL has been configured in the URLAttribute, and the given String is not an absolute URL,
 /// it will return an absolute URL, relative to the baseURL.
 private struct URLValueFormatter: ValueFormatter {
-	func unformatValue(_ value: String, forAttribute attribute: URLAttribute) -> URL {
-		return URL(string: value, relativeTo: attribute.baseURL as URL?)!
-	}
-	
-	func formatValue(_ value: URL, forAttribute attribute: URLAttribute) -> String {
-		return value.absoluteString
-	}
+    func unformatValue(_ value: String?, forAttribute attribute: URLAttribute) -> URL? {
+        guard let value = value else {
+            return nil
+        }
+        return URL(string: value, relativeTo: attribute.baseURL)
+    }
+    
+    func formatValue(_ value: URL?, forAttribute attribute: URLAttribute) -> String? {
+        return value?.absoluteString
+    }
 }
 
 /// DateValueFormatter is a value formatter that transforms between NSDate and String, and vice versa.


### PR DESCRIPTION
Making the URLValueFormatter more resilient. 
If the string value passed in the unformatValue is not one representing a valid url, now the URL init is not force unwrapped, so if it fails the code will not crash anymore. The scenario in with the URL creation fails is now managed.
Example input that makes the URLValueFormatter crash is "http://example.com/page1\"" (with an escaped quote at the end).